### PR TITLE
net: migrate to declarative net request

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,7 @@
     "description": "__MSG_extensionDescription__",
     "default_locale": "en",
     "permissions": [
-        "webRequest",
-        "webRequestBlocking",
+        "declarativeNetRequest",
         "webNavigation",
         "tabs",
         "storage",

--- a/src/bg/ua-inject.js
+++ b/src/bg/ua-inject.js
@@ -5,7 +5,7 @@ import { C } from '../common/constants.js';
 
 const { extractHostname } = util;
 const UA_HEADER = 'user-agent';
-const CLIENT_HINTS_HEADERS = [
+export const CLIENT_HINTS_HEADERS = [
     'sec-ch-ua', 'sec-ch-ua-mobile',
     'sec-ch-ua-platform', 'sec-ch-ua-platform-version',
     'sec-ch-ua-model', 'sec-ch-ua-arch', 'sec-ch-ua-bitness',
@@ -45,7 +45,7 @@ function setOrAddUAHeader(headers, ua) {
     headersToBag(headers).set('User-Agent', ua);
 }
 
-function shimUA(ua) {
+export function shimUA(ua) {
     const rv = (ua.match(/rv:(\d+)/) || [])[1] || '0';
     const isWin = /Windows NT/i.test(ua);
     const isLinux = /Linux|X11/i.test(ua);


### PR DESCRIPTION
## Summary
- expose UA shim helpers for declarative rules
- handle request headers and redirects with declarativeNetRequest
- update background wiring and manifest for DNR permissions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a428eea378832ca21f8cd0a5e0b207